### PR TITLE
Alter Sign Up API to send cookeis post successful sign up

### DIFF
--- a/5-main-project/src/routes/auth.js
+++ b/5-main-project/src/routes/auth.js
@@ -47,6 +47,9 @@ authRouter.post('/signup', async (request, response) => {
 
             const user = await newUser.save(); // Push Data in the collection.
 
+            const authToken = jwt.sign({ _id: user._id }, "Sarthak@1234", { expiresIn: "7d" });
+            response.cookie("authToken", authToken, { httpOnly: true, expires: new Date(Date.now() + 60 * 60 * 1000) });
+
             response.json({
                 message: `Congratulations ${newUser.firstName}, you're signed up sucessfully!!`,
                 data: user,

--- a/5-main-project/src/routes/request.js
+++ b/5-main-project/src/routes/request.js
@@ -81,8 +81,6 @@ requestRouter.post("/request/review/:status/:requestId", authenticateUser, async
 
         existingConnectionRequest.status =  `${status}ed`;
 
-        console.log(existingConnectionRequest.status);
-
         const data = await existingConnectionRequest.save();
 
         response.json({


### PR DESCRIPTION
Contains changes for
1. Generating jwt token and sending cookies post successful signup.
2. Remove unwanted console.log